### PR TITLE
Assumable role module for a federated user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,9 @@
 *.tfstate
 *.tfstate.*
 
-# Test lock file
+# Test lock files
 test/.terraform.lock.hcl
+**/test/.terraform.lock.hcl
 
 # Crash log files
 crash.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# ap-terraform-iam-roles
+
+This repository contains modules that implement IAM role patterns used accross the AP code base.
+
+Previously, these patterns have been implemented multiple times but in slightly different ways.
+In some cases that has been achieved by using the Terraform AWS IAM module.
+Those implementations are good but often overly complex and hard to debug.
+
+This is an attempt to co-locate all IAM role patterns in a single place, simplify and document them.
+
+It contains:
+
+- `eks-role`: a role that can be assumed by an EKS cluster
+- `assumable-role-federated-user`: a role that can be assumed by a federated user e.g. an `eks-role`

--- a/assumable-role-federated-user/.terraform-docs.yml
+++ b/assumable-role-federated-user/.terraform-docs.yml
@@ -1,0 +1,9 @@
+formatter: "markdown"
+
+output:
+  file: "README.md"
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->

--- a/assumable-role-federated-user/.tflint.hcl
+++ b/assumable-role-federated-user/.tflint.hcl
@@ -1,0 +1,22 @@
+config {
+  disabled_by_default = false
+}
+
+rule "terraform_comment_syntax" { enabled = true }
+rule "terraform_deprecated_index" { enabled = true }
+rule "terraform_documented_outputs" { enabled = true }
+rule "terraform_documented_variables" { enabled = true }
+rule "terraform_naming_convention" { enabled = true }
+rule "terraform_required_providers" { enabled = true }
+rule "terraform_required_version" { enabled = true }
+rule "terraform_standard_module_structure" { enabled = true }
+rule "terraform_typed_variables" { enabled = true }
+rule "terraform_unused_declarations" { enabled = true }
+rule "terraform_unused_required_providers" { enabled = true }
+
+plugin "aws" {
+    enabled = true
+    version = "0.13.4"
+    source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+

--- a/assumable-role-federated-user/README.md
+++ b/assumable-role-federated-user/README.md
@@ -1,0 +1,55 @@
+# assumable-role-federated-user
+
+Creates a role that can be assumed by a federated user (i.e. they have already assumed a role).
+This is intended to be used by an `eks-role` or `github-action-federated-id-role` that requires cross account access.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.71.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.71.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | Whether policies should be detached from this role when destroying | `bool` | `true` | no |
+| <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `3600` | no |
+| <a name="input_role_description"></a> [role\_description](#input\_role\_description) | IAM Role description | `string` | n/a | yes |
+| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | IAM role name | `string` | `null` | no |
+| <a name="input_role_name_prefix"></a> [role\_name\_prefix](#input\_role\_name\_prefix) | IAM role name prefix | `string` | `null` | no |
+| <a name="input_role_path"></a> [role\_path](#input\_role\_path) | Path of IAM role | `string` | `"/"` | no |
+| <a name="input_role_permissions_boundary_arn"></a> [role\_permissions\_boundary\_arn](#input\_role\_permissions\_boundary\_arn) | Permissions boundary ARN to use for IAM role | `string` | `null` | no |
+| <a name="input_role_policy_arns"></a> [role\_policy\_arns](#input\_role\_policy\_arns) | List of ARNs of IAM policies to attach to IAM role | `list(string)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to IAM role resources | `map(string)` | `{}` | no |
+| <a name="input_trusted_entity_arns"></a> [trusted\_entity\_arns](#input\_trusted\_entity\_arns) | ARNs of AWS entities who can assume this role | `list(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | ARN of IAM role |
+| <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | Name of IAM role |
+| <a name="output_iam_role_path"></a> [iam\_role\_path](#output\_iam\_role\_path) | Path of IAM role |
+| <a name="output_iam_role_unique_id"></a> [iam\_role\_unique\_id](#output\_iam\_role\_unique\_id) | Unique ID of IAM role |
+<!-- END_TF_DOCS -->

--- a/assumable-role-federated-user/main.tf
+++ b/assumable-role-federated-user/main.tf
@@ -1,0 +1,33 @@
+data "aws_iam_policy_document" "assume_role" {
+
+  statement {
+    effect = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "AWS"
+      identifiers = var.trusted_entity_arns
+    }
+  }
+}
+
+
+resource "aws_iam_role" "this" {
+
+  assume_role_policy    = data.aws_iam_policy_document.assume_role.json
+  description           = var.role_description
+  force_detach_policies = var.force_detach_policies
+  max_session_duration  = var.max_session_duration
+  name                  = var.role_name
+  name_prefix           = var.role_name_prefix
+  path                  = var.role_path
+  permissions_boundary  = var.role_permissions_boundary_arn
+  tags                  = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  count = length(var.role_policy_arns)
+
+  role       = aws_iam_role.this.name
+  policy_arn = element(var.role_policy_arns, count.index)
+
+}

--- a/assumable-role-federated-user/outputs.tf
+++ b/assumable-role-federated-user/outputs.tf
@@ -1,0 +1,19 @@
+output "iam_role_arn" {
+  description = "ARN of IAM role"
+  value       = aws_iam_role.this.arn
+}
+
+output "iam_role_name" {
+  description = "Name of IAM role"
+  value       = aws_iam_role.this.name
+}
+
+output "iam_role_path" {
+  description = "Path of IAM role"
+  value       = aws_iam_role.this.path
+}
+
+output "iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = aws_iam_role.this.unique_id
+}

--- a/assumable-role-federated-user/test/README.md
+++ b/assumable-role-federated-user/test/README.md
@@ -1,0 +1,8 @@
+# Test
+
+Configuration here SHOULD allow a user to successfully perform:
+
+- `terrafrom init`
+- `terraform validate`
+
+It COULD form a complete example and allow a user to successfully perform `terraform apply` although this is not neccessary.

--- a/assumable-role-federated-user/test/main.tf
+++ b/assumable-role-federated-user/test/main.tf
@@ -1,0 +1,10 @@
+module "example" {
+  source           = "./.."
+  role_name_prefix = "TestFederatedRole"
+  trusted_entity_arns = [
+    "arn:aws:iam::042130406152:role/GlobalGitHubActionAccess",
+    "arn:aws:iam::042130406152:role/restricted-admin"
+  ]
+  role_description = "Role to test assumable-role-federated-user role"
+  role_policy_arns = ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
+}

--- a/assumable-role-federated-user/test/outputs.tf
+++ b/assumable-role-federated-user/test/outputs.tf
@@ -1,0 +1,4 @@
+# output "example_output" {
+#   description = "example output"
+#   value       = 
+# }

--- a/assumable-role-federated-user/test/variables.tf
+++ b/assumable-role-federated-user/test/variables.tf
@@ -1,0 +1,4 @@
+# variable "example" {
+#   description = "This is an example variable"
+#   type        = string
+# }

--- a/assumable-role-federated-user/test/versions.tf
+++ b/assumable-role-federated-user/test/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.71.0"
+    }
+  }
+
+  required_version = ">= 0.14.0"
+}

--- a/assumable-role-federated-user/variables.tf
+++ b/assumable-role-federated-user/variables.tf
@@ -1,0 +1,56 @@
+variable "trusted_entity_arns" {
+  description = "ARNs of AWS entities who can assume this role"
+  type        = list(string)
+}
+
+variable "tags" {
+  description = "A map of tags to add to IAM role resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "role_name" {
+  description = "IAM role name"
+  type        = string
+  default     = null
+}
+
+variable "role_name_prefix" {
+  description = "IAM role name prefix"
+  type        = string
+  default     = null
+}
+
+variable "role_description" {
+  description = "IAM Role description"
+  type        = string
+}
+
+variable "role_path" {
+  description = "Path of IAM role"
+  type        = string
+  default     = "/"
+}
+
+variable "role_permissions_boundary_arn" {
+  description = "Permissions boundary ARN to use for IAM role"
+  type        = string
+  default     = null
+}
+
+variable "max_session_duration" {
+  description = "Maximum CLI/API session duration in seconds between 3600 and 43200"
+  type        = number
+  default     = 3600
+}
+
+variable "role_policy_arns" {
+  description = "List of ARNs of IAM policies to attach to IAM role"
+  type        = list(string)
+}
+
+variable "force_detach_policies" {
+  description = "Whether policies should be detached from this role when destroying"
+  type        = bool
+  default     = true
+}

--- a/assumable-role-federated-user/versions.tf
+++ b/assumable-role-federated-user/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.71.0"
+    }
+  }
+
+  required_version = ">= 0.14.0"
+}


### PR DESCRIPTION
**JIRA**: ANPL-1160

## What has changed?

Added a module that provisions an assumable role that is to be used by a federated user.

## Why is this needed?

Part of refactoring and rationalising the way in which IAM is provisioned across the AP estate.

## What should the reviewer concentrate on?

Design; code quality
