### PR TITLE
Module to create GitHub action role

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,5 @@ This is an attempt to co-locate all IAM role patterns in a single place, simplif
 It contains:
 
 - `eks-role`: a role that can be assumed by an EKS cluster
+- `github-action-role`: a role that can be assumed by GitHub actions in a repo or repos
 - `assumable-role-federated-user`: a role that can be assumed by a federated user e.g. an `eks-role`

--- a/github-action-role/.terraform-docs.yml
+++ b/github-action-role/.terraform-docs.yml
@@ -1,0 +1,9 @@
+formatter: "markdown"
+
+output:
+  file: "README.md"
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->

--- a/github-action-role/.tflint.hcl
+++ b/github-action-role/.tflint.hcl
@@ -1,0 +1,21 @@
+config {
+  disabled_by_default = false
+}
+
+rule "terraform_comment_syntax" { enabled = true }
+rule "terraform_deprecated_index" { enabled = true }
+rule "terraform_documented_outputs" { enabled = true }
+rule "terraform_documented_variables" { enabled = true }
+rule "terraform_naming_convention" { enabled = true }
+rule "terraform_required_providers" { enabled = true }
+rule "terraform_required_version" { enabled = true }
+rule "terraform_standard_module_structure" { enabled = true }
+rule "terraform_typed_variables" { enabled = true }
+rule "terraform_unused_declarations" { enabled = true }
+rule "terraform_unused_required_providers" { enabled = true }
+
+plugin "aws" {
+    enabled = true
+    version = "0.13.4"
+    source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}

--- a/github-action-role/README.md
+++ b/github-action-role/README.md
@@ -1,0 +1,60 @@
+# github-action-role
+
+Module that provisions a role that can be assumed by GitHub actions in a repo or repos.
+See [here](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect) for more detail.
+
+This module assumes the GitHub OIDC provider has already been provisioned.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.71.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.71.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | Whether policies should be detached from this role when destroying | `bool` | `true` | no |
+| <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `3600` | no |
+| <a name="input_provider_url"></a> [provider\_url](#input\_provider\_url) | URL of the cluster GitHub OIDC Provider | `string` | n/a | yes |
+| <a name="input_role_description"></a> [role\_description](#input\_role\_description) | IAM Role description | `string` | n/a | yes |
+| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | IAM role name | `string` | `null` | no |
+| <a name="input_role_name_prefix"></a> [role\_name\_prefix](#input\_role\_name\_prefix) | IAM role name prefix | `string` | `null` | no |
+| <a name="input_role_path"></a> [role\_path](#input\_role\_path) | Path of IAM role | `string` | `"/"` | no |
+| <a name="input_role_permissions_boundary_arn"></a> [role\_permissions\_boundary\_arn](#input\_role\_permissions\_boundary\_arn) | Permissions boundary ARN to use for IAM role | `string` | `null` | no |
+| <a name="input_role_policy_arns"></a> [role\_policy\_arns](#input\_role\_policy\_arns) | List of ARNs of IAM policies to attach to IAM role | `list(string)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to IAM role resources | `map(string)` | `{}` | no |
+| <a name="input_trusted_org_repos"></a> [trusted\_org\_repos](#input\_trusted\_org\_repos) | A list of GitHub organisation repositories that can assume this role in the form $org:$repo | `list(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | ARN of IAM role |
+| <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | Name of IAM role |
+| <a name="output_iam_role_path"></a> [iam\_role\_path](#output\_iam\_role\_path) | Path of IAM role |
+| <a name="output_iam_role_unique_id"></a> [iam\_role\_unique\_id](#output\_iam\_role\_unique\_id) | Unique ID of IAM role |
+<!-- END_TF_DOCS -->

--- a/github-action-role/main.tf
+++ b/github-action-role/main.tf
@@ -1,0 +1,51 @@
+locals {
+  provider_url_normalised = replace(var.provider_url, "https://", "")
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+data "aws_iam_policy_document" "assume_role" {
+
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = ["arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${local.provider_url_normalised}"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = formatlist("repo:%s:*", var.trusted_org_repos)
+    }
+    effect = "Allow"
+  }
+
+}
+
+resource "aws_iam_role" "this" {
+
+  assume_role_policy    = data.aws_iam_policy_document.assume_role.json
+  description           = var.role_description
+  force_detach_policies = var.force_detach_policies
+  max_session_duration  = var.max_session_duration
+  name                  = var.role_name
+  name_prefix           = var.role_name_prefix
+  path                  = var.role_path
+  permissions_boundary  = var.role_permissions_boundary_arn
+  tags                  = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  count = length(var.role_policy_arns)
+
+  role       = aws_iam_role.this.name
+  policy_arn = element(var.role_policy_arns, count.index)
+
+}

--- a/github-action-role/outputs.tf
+++ b/github-action-role/outputs.tf
@@ -1,0 +1,19 @@
+output "iam_role_arn" {
+  description = "ARN of IAM role"
+  value       = aws_iam_role.this.arn
+}
+
+output "iam_role_name" {
+  description = "Name of IAM role"
+  value       = aws_iam_role.this.name
+}
+
+output "iam_role_path" {
+  description = "Path of IAM role"
+  value       = aws_iam_role.this.path
+}
+
+output "iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = aws_iam_role.this.unique_id
+}

--- a/github-action-role/test/README.md
+++ b/github-action-role/test/README.md
@@ -1,0 +1,8 @@
+# Test
+
+Configuration here SHOULD allow a user to successfully perform:
+
+- `terrafrom init`
+- `terraform validate`
+
+It COULD form a complete example and allow a user to successfully perform `terraform apply` although this is not neccessary.

--- a/github-action-role/test/main.tf
+++ b/github-action-role/test/main.tf
@@ -1,0 +1,11 @@
+module "example" {
+  source       = "./.."
+  provider_url = "https://token.actions.githubusercontent.com"
+  trusted_org_repos = [
+    "trustedorg:repo",
+    "anotherorg:anotherrepo"
+  ]
+  role_name_prefix = "TestGitHubFederatedIDRole"
+  role_description = "Role to test github-action-federated-id role"
+  role_policy_arns = ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
+}

--- a/github-action-role/test/outputs.tf
+++ b/github-action-role/test/outputs.tf
@@ -1,0 +1,4 @@
+# output "example_output" {
+#   description = "example output"
+#   value       = 
+# }

--- a/github-action-role/test/variables.tf
+++ b/github-action-role/test/variables.tf
@@ -1,0 +1,4 @@
+# variable "example" {
+#   description = "This is an example variable"
+#   type        = string
+# }

--- a/github-action-role/test/versions.tf
+++ b/github-action-role/test/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.71.0"
+    }
+  }
+
+  required_version = ">= 0.14.0"
+}

--- a/github-action-role/variables.tf
+++ b/github-action-role/variables.tf
@@ -1,0 +1,61 @@
+variable "trusted_org_repos" {
+  description = "A list of GitHub organisation repositories that can assume this role in the form $org:$repo"
+  type        = list(string)
+}
+
+variable "provider_url" {
+  description = "URL of the cluster GitHub OIDC Provider"
+  type        = string
+}
+
+variable "tags" {
+  description = "A map of tags to add to IAM role resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "role_name" {
+  description = "IAM role name"
+  type        = string
+  default     = null
+}
+
+variable "role_name_prefix" {
+  description = "IAM role name prefix"
+  type        = string
+  default     = null
+}
+
+variable "role_description" {
+  description = "IAM Role description"
+  type        = string
+}
+
+variable "role_path" {
+  description = "Path of IAM role"
+  type        = string
+  default     = "/"
+}
+
+variable "role_permissions_boundary_arn" {
+  description = "Permissions boundary ARN to use for IAM role"
+  type        = string
+  default     = null
+}
+
+variable "max_session_duration" {
+  description = "Maximum CLI/API session duration in seconds between 3600 and 43200"
+  type        = number
+  default     = 3600
+}
+
+variable "role_policy_arns" {
+  description = "List of ARNs of IAM policies to attach to IAM role"
+  type        = list(string)
+}
+
+variable "force_detach_policies" {
+  description = "Whether policies should be detached from this role when destroying"
+  type        = bool
+  default     = true
+}

--- a/github-action-role/versions.tf
+++ b/github-action-role/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.71.0"
+    }
+  }
+
+  required_version = ">= 0.14.0"
+}


### PR DESCRIPTION
**JIRA**: ANPL-1156

## What has changed?

Added a role that can be assumed by a GitHub action within a GitHub repo or repos.

## Why is this needed?

This is pre-cursor work to provisioning GitHub action multi-account IAM for the DataEngineer's CICD.

## What should the reviewer concentrate on?

Design; code quality
