### PR TITLE
feat: adds assumable role for an IAM user

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@ It contains:
 - `eks-role`: a role that can be assumed by an EKS cluster
 - `github-action-role`: a role that can be assumed by GitHub actions in a repo or repos
 - `assumable-role-federated-user`: a role that can be assumed by a federated user e.g. an `eks-role`
+- `assumable-iam-user`: a role that can be assumed by an IAM user or group in trusted account

--- a/assumable-role-iam-user/.terraform-docs.yml
+++ b/assumable-role-iam-user/.terraform-docs.yml
@@ -1,0 +1,9 @@
+formatter: "markdown"
+
+output:
+  file: "README.md"
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->

--- a/assumable-role-iam-user/.tflint.hcl
+++ b/assumable-role-iam-user/.tflint.hcl
@@ -1,0 +1,22 @@
+config {
+  disabled_by_default = false
+}
+
+rule "terraform_comment_syntax" { enabled = true }
+rule "terraform_deprecated_index" { enabled = true }
+rule "terraform_documented_outputs" { enabled = true }
+rule "terraform_documented_variables" { enabled = true }
+rule "terraform_naming_convention" { enabled = true }
+rule "terraform_required_providers" { enabled = true }
+rule "terraform_required_version" { enabled = true }
+rule "terraform_standard_module_structure" { enabled = true }
+rule "terraform_typed_variables" { enabled = true }
+rule "terraform_unused_declarations" { enabled = true }
+rule "terraform_unused_required_providers" { enabled = true }
+
+plugin "aws" {
+    enabled = true
+    version = "0.13.4"
+    source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+

--- a/assumable-role-iam-user/README.md
+++ b/assumable-role-iam-user/README.md
@@ -1,0 +1,55 @@
+# assumable-role-iam-user
+
+Creates a role that can be assumed by an IAM user.
+This is intended to be used by humans who require cross account access.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.71.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.71.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | Whether policies should be detached from this role when destroying | `bool` | `true` | no |
+| <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum CLI/API session duration in seconds between 3600 and 43200 | `number` | `3600` | no |
+| <a name="input_role_description"></a> [role\_description](#input\_role\_description) | IAM Role description | `string` | n/a | yes |
+| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | IAM role name | `string` | `null` | no |
+| <a name="input_role_name_prefix"></a> [role\_name\_prefix](#input\_role\_name\_prefix) | IAM role name prefix | `string` | `null` | no |
+| <a name="input_role_path"></a> [role\_path](#input\_role\_path) | Path of IAM role | `string` | `"/"` | no |
+| <a name="input_role_permissions_boundary_arn"></a> [role\_permissions\_boundary\_arn](#input\_role\_permissions\_boundary\_arn) | Permissions boundary ARN to use for IAM role | `string` | `null` | no |
+| <a name="input_role_policy_arns"></a> [role\_policy\_arns](#input\_role\_policy\_arns) | List of ARNs of IAM policies to attach to IAM role | `list(string)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to IAM role resources | `map(string)` | `{}` | no |
+| <a name="input_trusted_account_id"></a> [trusted\_account\_id](#input\_trusted\_account\_id) | ID of the account which this role should trust | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_iam_role_arn"></a> [iam\_role\_arn](#output\_iam\_role\_arn) | ARN of IAM role |
+| <a name="output_iam_role_name"></a> [iam\_role\_name](#output\_iam\_role\_name) | Name of IAM role |
+| <a name="output_iam_role_path"></a> [iam\_role\_path](#output\_iam\_role\_path) | Path of IAM role |
+| <a name="output_iam_role_unique_id"></a> [iam\_role\_unique\_id](#output\_iam\_role\_unique\_id) | Unique ID of IAM role |
+<!-- END_TF_DOCS -->

--- a/assumable-role-iam-user/main.tf
+++ b/assumable-role-iam-user/main.tf
@@ -1,0 +1,37 @@
+data "aws_iam_policy_document" "assume_role" {
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "AWS"
+      identifiers = [var.trusted_account_id]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "sts:RoleSessionName"
+      values   = ["&{aws:username}"]
+    }
+  }
+}
+
+resource "aws_iam_role" "this" {
+
+  assume_role_policy    = data.aws_iam_policy_document.assume_role.json
+  description           = var.role_description
+  force_detach_policies = var.force_detach_policies
+  max_session_duration  = var.max_session_duration
+  name                  = var.role_name
+  name_prefix           = var.role_name_prefix
+  path                  = var.role_path
+  permissions_boundary  = var.role_permissions_boundary_arn
+  tags                  = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "this" {
+  count = length(var.role_policy_arns)
+
+  role       = aws_iam_role.this.name
+  policy_arn = element(var.role_policy_arns, count.index)
+
+}

--- a/assumable-role-iam-user/outputs.tf
+++ b/assumable-role-iam-user/outputs.tf
@@ -1,0 +1,19 @@
+output "iam_role_arn" {
+  description = "ARN of IAM role"
+  value       = aws_iam_role.this.arn
+}
+
+output "iam_role_name" {
+  description = "Name of IAM role"
+  value       = aws_iam_role.this.name
+}
+
+output "iam_role_path" {
+  description = "Path of IAM role"
+  value       = aws_iam_role.this.path
+}
+
+output "iam_role_unique_id" {
+  description = "Unique ID of IAM role"
+  value       = aws_iam_role.this.unique_id
+}

--- a/assumable-role-iam-user/test/README.md
+++ b/assumable-role-iam-user/test/README.md
@@ -1,0 +1,8 @@
+# Test
+
+Configuration here SHOULD allow a user to successfully perform:
+
+- `terrafrom init`
+- `terraform validate`
+
+It COULD form a complete example and allow a user to successfully perform `terraform apply` although this is not neccessary.

--- a/assumable-role-iam-user/test/main.tf
+++ b/assumable-role-iam-user/test/main.tf
@@ -1,0 +1,7 @@
+module "example" {
+  source             = "./.."
+  role_name_prefix   = "TestIAMRole"
+  trusted_account_id = "525294151996"
+  role_description   = "Role to test assumable-role-IAM-user role"
+  role_policy_arns   = ["arn:aws:iam::aws:policy/ReadOnlyAccess"]
+}

--- a/assumable-role-iam-user/test/outputs.tf
+++ b/assumable-role-iam-user/test/outputs.tf
@@ -1,0 +1,4 @@
+# output "example_output" {
+#   description = "example output"
+#   value       = 
+# }

--- a/assumable-role-iam-user/test/variables.tf
+++ b/assumable-role-iam-user/test/variables.tf
@@ -1,0 +1,4 @@
+# variable "example" {
+#   description = "This is an example variable"
+#   type        = string
+# }

--- a/assumable-role-iam-user/test/versions.tf
+++ b/assumable-role-iam-user/test/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.71.0"
+    }
+  }
+
+  required_version = ">= 0.14.0"
+}

--- a/assumable-role-iam-user/variables.tf
+++ b/assumable-role-iam-user/variables.tf
@@ -1,0 +1,56 @@
+variable "trusted_account_id" {
+  description = "ID of the account which this role should trust"
+  type        = string
+}
+
+variable "tags" {
+  description = "A map of tags to add to IAM role resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "role_name" {
+  description = "IAM role name"
+  type        = string
+  default     = null
+}
+
+variable "role_name_prefix" {
+  description = "IAM role name prefix"
+  type        = string
+  default     = null
+}
+
+variable "role_description" {
+  description = "IAM Role description"
+  type        = string
+}
+
+variable "role_path" {
+  description = "Path of IAM role"
+  type        = string
+  default     = "/"
+}
+
+variable "role_permissions_boundary_arn" {
+  description = "Permissions boundary ARN to use for IAM role"
+  type        = string
+  default     = null
+}
+
+variable "max_session_duration" {
+  description = "Maximum CLI/API session duration in seconds between 3600 and 43200"
+  type        = number
+  default     = 3600
+}
+
+variable "role_policy_arns" {
+  description = "List of ARNs of IAM policies to attach to IAM role"
+  type        = list(string)
+}
+
+variable "force_detach_policies" {
+  description = "Whether policies should be detached from this role when destroying"
+  type        = bool
+  default     = true
+}

--- a/assumable-role-iam-user/versions.tf
+++ b/assumable-role-iam-user/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.71.0"
+    }
+  }
+
+  required_version = ">= 0.14.0"
+}


### PR DESCRIPTION
**JIRA**: ANPL-1169

## What has changed?

Added module that allows an IAM user in a trusted account to assume it. It enforces the session ID must match the user name.

## Why is this needed?

This is pre-cursor work to enable PenTesters to access the AP and DE accounts and is in line with the intended refactoring of the AP/DE shared IAM.

## What should the reviewer concentrate on?

Design; code quality
