### PR TITLE
Update to daily scheduled linter run

### DIFF
--- a/.github/workflows/repository-github-super-linter.yml
+++ b/.github/workflows/repository-github-super-linter.yml
@@ -12,7 +12,7 @@ on: # yamllint disable-line rule:truthy
       - synchronize
 
   schedule:
-    - cron: 10 * * * *
+    - cron: 17 4 * * 1-5
 
 permissions: read-all
 


### PR DESCRIPTION
#1078

## What has changed?

Chnaged the date/time of the Super Linter scheduled run

## Why is this needed?

Currently the linter is running hourly (for testing).  This change amends the cron schedule to run the linter once per day Mon-Fri.

## What should the reviewer concentrate on?

Cron schedule is correct.
